### PR TITLE
[Cải thiện] Class cho việc gửi thông báo Toast

### DIFF
--- a/src/lib/ToastNotification.ts
+++ b/src/lib/ToastNotification.ts
@@ -1,0 +1,48 @@
+import { getToastStore, type ToastStore } from "@skeletonlabs/skeleton";
+
+/**
+ * Các kiểu thông báo cho toast.
+ * 
+ * Kiểu khác nhau sẽ cho ra CSS khác nhau.
+ * 
+ */
+export enum StatusType {
+    Infomative = "variant-filled-secondary", 
+    Success = "variant-filled-success",
+    Error = "variant-filled-error",
+    Warning = "variant-filled-warning",
+}
+
+/**
+ * Class được tối giản hoá từ thư viện Skeleton.
+ */
+export default class ToastNotification {
+    toastStore: ToastStore;
+
+    constructor() {
+        this.toastStore = getToastStore();
+    }
+
+    /**
+     * Gửi thông báo đến người dùng.
+     * @param type Kiểu thông báo, lấy từ `StatusType`.
+     * @param message Thông điệp muốn gửi.
+     * @returns Trả về ID của thông báo này.
+     */
+
+    notify(type: StatusType, message: string) {
+        return this.toastStore.trigger({
+			message: message || 'Có lỗi xảy ra, hãy thử lại sau!',
+			hideDismiss: true,
+			background: type
+		});
+    }
+
+    /**
+     * Xoá tất cả các thông báo.
+     */
+
+    clear() {
+        this.toastStore.clear();
+    }
+}


### PR DESCRIPTION
Class này được viết để phục vụ cho việc viết thông báo Toast dễ dàng hơn và không phải thêm 3 dòng cho việc thông báo.

Ví dụ:
```js
import ToastNotification, { StatusType } from '$lib/ToastNotification';

const toast = new ToastNotification();
toast.notify(StatusType.Informative, "Đã thêm vào danh sách yêu thích");
```

Khuyến khích nên sử dụng class này vì đã được viết doc đầy đủ.